### PR TITLE
drivers: iio: smi330: Fix unannotated fall-through

### DIFF
--- a/drivers/iio/imu/smi330/smi330_core.c
+++ b/drivers/iio/imu/smi330/smi330_core.c
@@ -2576,6 +2576,7 @@ static int smi330_read_event_value(struct iio_dev *indio_dev,
 				*val = data->cfg.tilt_cfg.tilt_2.fields
 					       .beta_acc_mean;
 		}
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
Fix

drivers/iio/imu/smi330/smi330_core.c:2579:2: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
 2579 |         default:
      |         ^
drivers/iio/imu/smi330/smi330_core.c:2579:2: note: insert 'break;' to avoid fall-through
 2579 |         default:
      |         ^
      |         break;
1 error generated.