### PR TITLE
drivers: iio: smi330: Fix I2C probe() API mismatch

### DIFF
--- a/drivers/iio/imu/smi330/smi330_i2c.c
+++ b/drivers/iio/imu/smi330/smi330_i2c.c
@@ -46,6 +46,7 @@
 #include <linux/i2c.h>
 #include <linux/module.h>
 #include <linux/regmap.h>
+#include <linux/version.h>
 
 #include "smi330.h"
 
@@ -137,8 +138,12 @@ static const struct regmap_config smi330_regmap_config = {
 	.val_format_endian = REGMAP_ENDIAN_LITTLE,
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
 static int smi330_i2c_probe(struct i2c_client *i2c,
 			    const struct i2c_device_id *id)
+#else
+static int smi330_i2c_probe(struct i2c_client *i2c)
+#endif
 {
 	struct device *dev = &i2c->dev;
 	struct smi330_i2c_priv *priv;


### PR DESCRIPTION
With kernel >= v6.10 the `i2c_device_id` parameter was dropped from smi330_i2c_probe(). See

commit 03c835f498b5 ("i2c: Switch .probe() to not take an id parameter")

For kernel's >= v6.10 this will result in

drivers/iio/imu/smi330/smi330_i2c.c:171:11: error: incompatible
  function pointer types initializing 'int (*)(struct i2c_client *)'
  with an expression of type 'int (struct i2c_client *, const struct
  i2c_device_id *)' [-Wincompatible-function-pointer-types]
  171 |         .probe = smi330_i2c_probe,
      |                  ^~~~~~~~~~~~~~~~
1 error generated.

Fix this by checking the kernel version information.