### PR TITLE
drivers: iio: smi330: Fix uninitialized variables

### DIFF
--- a/drivers/iio/imu/smi330/smi330_core.c
+++ b/drivers/iio/imu/smi330/smi330_core.c
@@ -2258,6 +2258,8 @@ static int smi330_write_event_config(struct iio_dev *indio_dev,
 				en_val = FIELD_PREP(en_mask, state);
 				break;
 			default:
+				en_mask = 0;
+				en_val = 0;
 				break;
 			}
 			int_mask = SMI330_INT_MAP1_ANYMO_MASK;
@@ -2278,6 +2280,8 @@ static int smi330_write_event_config(struct iio_dev *indio_dev,
 				en_val = FIELD_PREP(en_mask, state);
 				break;
 			default:
+				en_mask = 0;
+				en_val = 0;
 				break;
 			}
 			int_mask = SMI330_INT_MAP1_NOMO_MASK;


### PR DESCRIPTION
Fix

drivers/iio/imu/smi330/smi330_core.c:2260/2280:4: warning:
  variable 'en_mask' is used uninitialized whenever switch
  default is taken [-Wsometimes-uninitialized]\n" error,
  forbidden warning: smi330_core.c:2260/2280